### PR TITLE
fixed hooks not working anywhere outside special circumstances

### DIFF
--- a/src/hooks/queryapps.js
+++ b/src/hooks/queryapps.js
@@ -7,14 +7,22 @@ react-query hook to keep track of multiple apps. The idea is that main admins an
 
 // GET request for applications to specified org.
 async function getApps(auth, orgid) {
-  const token = auth.authState.accessToken;
-  return await axiosWithAuth(token).get(`/orgs/org/${orgid}/apps`);
+  return auth.authService
+    .getAccessToken()
+    .then(token => {
+      return axiosWithAuth(token).get(`/orgs/org/${orgid}/apps`);
+    })
+    .catch(error => console.error(error));
 }
 
 // PATCH for an application
 function patchApp(auth, appData) {
-  const token = auth.authState.accessToken;
-  return axiosWithAuth(token).patch(`apps/app/${appData.appid}`, appData);
+  return auth.authService
+    .getAccessToken()
+    .then(token => {
+      return axiosWithAuth(token).patch(`apps/app/${appData.appid}`, appData);
+    })
+    .catch(error => console.error(error));
 }
 
 // returns a mutation function that will update backend

--- a/src/hooks/queryorgs.js
+++ b/src/hooks/queryorgs.js
@@ -1,26 +1,44 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import axiosWithAuth from '../utils/axiosWithAuth';
+import axios from 'axios';
 
 /*
 react-query hooks to keep track of org/s. We're going to need to be able to just generically get all orgs, so a possible participant can see all the different orgs. We'll also want to query one at a time, and be able to patch them, so someone can update their orgs information.
 */
 
+// GET request for all orgs, no auth
+async function getOrgsNoAuth() {
+  return axios.get(`${process.env.REACT_APP_API_URI}/orgs/all`);
+}
+
 // GET request for all orgs.
 async function getOrgs(auth) {
-  const token = auth.authState.accessToken;
-  return await axiosWithAuth(token).get(`/orgs/all`);
+  return auth.authService
+    .getAccessToken()
+    .then(token => {
+      return axiosWithAuth(token).get(`/orgs/all`);
+    })
+    .catch(error => console.error(error));
 }
 
 // GET request for a single org.
 async function getOrg(auth, orgid) {
-  const token = auth.authState.accessToken;
-  return await axiosWithAuth(token).get(`/orgs/org/${orgid}`);
+  return auth.authService
+    .getAccessToken()
+    .then(token => {
+      return axiosWithAuth(token).get(`/orgs/org/${orgid}`);
+    })
+    .catch(error => console.error(error));
 }
 
 // PATCH for an org
-function patchOrg(auth, orgData) {
-  const token = auth.authState.accessToken;
-  return axiosWithAuth(token).patch(`orgs/org/${orgData.orgid}`, orgData);
+async function patchOrg(auth, orgData) {
+  return auth.authService
+    .getAccessToken()
+    .then(token => {
+      return axiosWithAuth(token).patch(`orgs/org/${orgData.orgid}`, orgData);
+    })
+    .catch(error => console.error(error));
 }
 
 // returns a mutation function that will update server state

--- a/src/hooks/queryuser.js
+++ b/src/hooks/queryuser.js
@@ -7,14 +7,25 @@ React-query hook to get and update the current users information. Should be able
 
 // GET request for /users/getuserinfo
 async function getUserInfo(auth) {
-  const token = auth.authState.accessToken;
-  return await axiosWithAuth(token).get(`/users/getuserinfo`);
+  return auth.authService
+    .getAccessToken()
+    .then(token => {
+      return axiosWithAuth(token).get(`/users/getuserinfo`);
+    })
+    .catch(error => console.error(error));
 }
 
 //  PATCH request to update userinfo
 function patchUser(auth, userData) {
-  const token = auth.authState.accessToken;
-  return axiosWithAuth(token).patch(`users/user/${userData.userid}`, userData);
+  return auth.authService
+    .getAccessToken()
+    .then(token => {
+      return axiosWithAuth(token).patch(
+        `users/user/${userData.userid}`,
+        userData
+      );
+    })
+    .catch(error => console.error(error));
 }
 
 // returns a mutation function that will update server state


### PR DESCRIPTION
## Quick fix to make query hooks work everywhere the way they should

I was building a component with my hooks, and quickly realized they only worked if authentication had already been received from okta (oops!). This changes a few lines, so that instead of only getting the accesstoken locally, and dying horribly if it's not already there. It will trigger the okta library to go get the token if it doesn't already have it.

To be more exact. I replaced using `auth.authState.accessToken` with the promise `auth.authService.getAccessToken()` Making things slightly more complicated, but _much_ more robust.

- [X]  Bug fix (non-breaking change which fixes an issue)