### PR TITLE
connect search components to back-end

### DIFF
--- a/src/components/pages/Dashboard/DashCard.js
+++ b/src/components/pages/Dashboard/DashCard.js
@@ -29,9 +29,12 @@ function DashCard() {
       <Profile />
       {/* Only partners/admins should see the dashcard
           however I'm leaving this as USER because there
-          are no partners/admins that you can log in as */}
+          are no partners/admins that you can log in as
+          ALSO, just grabbing the first org's orgid because
+          a person should only ever be part of one org
+                  data.data.organizations[0].orgid || {} */}
       {data.data.roles.filter(r => r.role.name == 'USER').length > 0 && (
-        <SearchPage />
+        <SearchPage orgId={5} />
       )}
       {data.data.roles.filter(r => r.role.name == 'USER').length > 0 && (
         <OrgCards />

--- a/src/components/pages/Dashboard/DashCard.js
+++ b/src/components/pages/Dashboard/DashCard.js
@@ -27,15 +27,19 @@ function DashCard() {
     <DashCardStyle>
       <h2>user_id dashboard</h2>
       <Profile />
-      {/* Only partners/admins should see the dashcard
-          however I'm leaving this as USER because there
-          are no partners/admins that you can log in as
-          ALSO, just grabbing the first org's orgid because
-          a person should only ever be part of one org
-                  data.data.organizations[0].orgid || {} */}
-      {data.data.roles.filter(r => r.role.name == 'USER').length > 0 && (
+      {/* Only partners/admins should see the dashcard however
+          none of the test users are PARTNER's or part of any
+          organization, so I'm hard-coding in orgId of 5.
+          Should be able to replace the ternary operator with
+          `&&`, and delete the last line to 'fix' this.
+      */}
+      {data.data.roles.filter(r => r.role.name == 'PARTNER').length > 0 &&
+      data.data.organizations[0] > 0 ? (
+        <SearchPage orgId={data.data.organizations[0].orgid || {}} />
+      ) : (
         <SearchPage orgId={5} />
       )}
+
       {data.data.roles.filter(r => r.role.name == 'USER').length > 0 && (
         <OrgCards />
       )}

--- a/src/components/pages/Search/CompactApp.js
+++ b/src/components/pages/Search/CompactApp.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { Modal, Button } from 'antd';
 import './search.css';
 
-function CompactApp({ app, filterValues }) {
+function CompactApp({ app, filterValues, mutation }) {
   const [modalState, setModalState] = useState({
     visible: false,
     loading: false,
@@ -18,6 +18,7 @@ function CompactApp({ app, filterValues }) {
 
   const handleAccept = e => {
     setModalState({ ...modalState, loading: true });
+    mutation.mutate({ ...app, status: 'accepted' });
     setTimeout(() => {
       setModalState({ loading: false, visible: false });
     }, 1000);
@@ -25,6 +26,7 @@ function CompactApp({ app, filterValues }) {
 
   const handleReject = e => {
     setModalState({ ...modalState, loading: true });
+    mutation.mutate({ ...app, status: 'rejected' });
     setTimeout(() => {
       setModalState({ loading: false, visible: false });
     }, 1000);

--- a/src/components/pages/Search/SearchPage.js
+++ b/src/components/pages/Search/SearchPage.js
@@ -5,33 +5,25 @@ import CompactApp from './CompactApp';
 import SearchInput from './SearchInput';
 import './search.css';
 import dummyData from './dummySearchData';
-import { useOktaAuth } from '@okta/okta-react';
-import { getProfileData } from '../../../api';
-import { useAppsQuery } from '../../../hooks';
+import { useOktaAuth } from '@okta/okta-react/dist/OktaContext';
+import { useAppsQuery, useUserQuery } from '../../../hooks';
 
-function SearchPage() {
-  /* Lines 14 and 15, to my understanding, will be necessary to use the useAppsQuery to 
-  retrieve all of the applications using the react queries. I'm not yet sure how to 
-  retrieve all of the applications made to a specific organization, but I think
-  the getProfileData hook should be able to return an id or something that can
-  be passed to the neccessary endpoint link. Still figuring that out.*/
-
-  const { authState } = useOktaAuth();
-  getProfileData(authState);
-
+function SearchPage({ orgId }) {
+  // passing orgId down from the parent component, because I don't see
+  // an easy way to get data from one hook and use it in another hook
+  const auth = useOktaAuth();
+  const [{ data, isLoading, error }, mutation] = useAppsQuery(auth, orgId);
   const [apps, setAppsState] = useState([]);
   const [filterValues, setFilter] = useState({ name: '', status: '' });
 
   useEffect(() => {
-    axios
-      .get('https://micro-fund-be-b.herokuapp.com/apps/all')
-      .then(res => {
-        setAppsState(res.data);
-      })
-      .catch(err => {
-        console.log('Error: ', err);
-      });
-  }, [filterValues]); // Rerender the page when the filter values have updated
+    if (data) {
+      setAppsState(data.data);
+    }
+  }, [data]);
+  if (error) {
+    console.error(error);
+  }
 
   return (
     <div className="search-page">
@@ -48,6 +40,7 @@ function SearchPage() {
             key={application.appid}
             app={application}
             filterValues={filterValues}
+            mutation={mutation}
           />
         ))}
       </div>

--- a/src/hooks/queryapps.js
+++ b/src/hooks/queryapps.js
@@ -20,7 +20,10 @@ function patchApp(auth, appData) {
   return auth.authService
     .getAccessToken()
     .then(token => {
-      return axiosWithAuth(token).patch(`apps/app/${appData.appid}`, appData);
+      return axiosWithAuth(token).patch(
+        `apps/app/${appData.appid}/status`,
+        appData
+      );
     })
     .catch(error => console.error(error));
 }


### PR DESCRIPTION
### Description
Basically, this is just plugging in my React-Query hooks into the Search/SearchPage/CompactApp Components
I've hard-coded everyone into seeing the applications for `orgId=5`, because none of our users seem to actually be in any organizations.

### Trello Cards
[sort and filter applications...](https://trello.com/c/xUBNDAcQ/28-3-as-a-partner-admin-i-can-sort-and-filter-submitted-applications-from-participant-by-name-and-by-date)
and
[...reject participant applications](https://trello.com/c/UXXDMc2r/27-3-as-a-partner-admin-i-can-accept-or-reject-participant-applications)

### Type of Change
- [x]  New feature (non-breaking change which adds functionality)